### PR TITLE
chore: updated releases

### DIFF
--- a/releases/2025/February.mdx
+++ b/releases/2025/February.mdx
@@ -1,23 +1,36 @@
 ---
 sidebar_position: 11
 toc_max_heading_level: 2
-slug: /
 ---
 
 import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 <VersionUpdateCard />
 
-## v0.25.1
+## v0.25.3 
+
+### 🐛 Bug Fixes
+
+- fix: rename tool from 'tool\_forge\_patch' to 'tool\_forge\_fs\_patch' [@amitksingh1490](https://github.com/amitksingh1490) ([#401](https://github.com/antinomyhq/forge/pull/401))
+
+
+---
+## v0.25.2 
+
+* No changes
+
+
+---
+## v0.25.1 
 
 ### 🧰 Maintenance
 
 - refactor: update system prompts and add tool usage instructions [@tusharmath](https://github.com/tusharmath) ([#391](https://github.com/antinomyhq/forge/pull/391))
 - chore(ci): add build-release-pr job for pull requests with 'build-all… [@amitksingh1490](https://github.com/amitksingh1490) ([#387](https://github.com/antinomyhq/forge/pull/387))
 
----
 
-## v0.25.0
+---
+## v0.25.0 
 
 ### 🚀 Features
 
@@ -27,9 +40,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - feat: separate out `user_task` into `user_task_init` and `user_task_update` events [@tusharmath](https://github.com/tusharmath) ([#385](https://github.com/antinomyhq/forge/pull/385))
 
----
 
-## v0.24.0
+---
+## v0.24.0 
 
 - feat: add `/dump` command [@tusharmath](https://github.com/tusharmath) ([#381](https://github.com/antinomyhq/forge/pull/381))
 
@@ -47,9 +60,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - feat: use YAML instead of TOML for defining workflows [@tusharmath](https://github.com/tusharmath) ([#384](https://github.com/antinomyhq/forge/pull/384))
 - chore: update dependencies to use specific features and disable defaults [@amitksingh1490](https://github.com/amitksingh1490) ([#382](https://github.com/antinomyhq/forge/pull/382))
 
----
 
-## v0.23.0
+---
+## v0.23.0 
 
 ### 🚀 Features
 
@@ -59,9 +72,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - fix: integration tests [@laststylebender14](https://github.com/laststylebender14) ([#379](https://github.com/antinomyhq/forge/pull/379))
 
----
 
-## v0.22.0
+---
+## v0.22.0 
 
 ### 🚀 Features
 
@@ -71,25 +84,25 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - fix: prevent workflow failure if agent fails to set the event [@laststylebender14](https://github.com/laststylebender14) ([#377](https://github.com/antinomyhq/forge/pull/377))
 
----
 
-## v0.21.2
+---
+## v0.21.2 
 
 ### 🐛 Bug Fixes
 
 - fix: curl script to download binary [@amitksingh1490](https://github.com/amitksingh1490) ([#371](https://github.com/antinomyhq/forge/pull/371))
 
----
 
-## v0.21.1
+---
+## v0.21.1 
 
 ### 🐛 Bug Fixes
 
 - refactor: add workflow service [@tusharmath](https://github.com/tusharmath) ([#369](https://github.com/antinomyhq/forge/pull/369))
 
----
 
-## v0.21.0
+---
+## v0.21.0 
 
 ### 🚀 Features
 
@@ -103,31 +116,31 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - refactor: remove unused provider and tool service modules; introduce new provider and tool traits [@tusharmath](https://github.com/tusharmath) ([#348](https://github.com/antinomyhq/forge/pull/348))
 
----
 
-## v0.20.0
+---
+## v0.20.0 
 
 ### 🚀 Features
 
 - feat: read workflow from toml [@amitksingh1490](https://github.com/amitksingh1490) ([#350](https://github.com/antinomyhq/forge/pull/350))
 
----
-
-## v0.19.1
-
-- No changes
 
 ---
+## v0.19.1 
 
-## v0.19.0
+* No changes
+
+
+---
+## v0.19.0 
 
 ### 🚀 Features
 
 - feat: set default to gnu instead of throwing an error [@ssddOnTop](https://github.com/ssddOnTop) ([#362](https://github.com/antinomyhq/forge/pull/362))
 
----
 
-## v0.18.0
+---
+## v0.18.0 
 
 ### 🚀 Features
 
@@ -139,17 +152,17 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - fix: remove unsupported commands [@laststylebender14](https://github.com/laststylebender14) ([#353](https://github.com/antinomyhq/forge/pull/353))
 - fix(CI): linux runtime errors [@ssddOnTop](https://github.com/ssddOnTop) ([#351](https://github.com/antinomyhq/forge/pull/351))
 
----
 
-## v0.17.1
+---
+## v0.17.1 
 
 ### 🐛 Bug Fixes
 
 - fix: enhance cache setting logic in transformer pipeline [@amitksingh1490](https://github.com/amitksingh1490) ([#357](https://github.com/antinomyhq/forge/pull/357))
 
----
 
-## v0.17.0
+---
+## v0.17.0 
 
 ### 🚀 Features
 
@@ -165,17 +178,17 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - refactor: support for workflow [@tusharmath](https://github.com/tusharmath) ([#343](https://github.com/antinomyhq/forge/pull/343))
 - chore: replace brackets with `<>` [@ssddOnTop](https://github.com/ssddOnTop) ([#342](https://github.com/antinomyhq/forge/pull/342))
 
----
 
-## v0.16.0
+---
+## v0.16.0 
 
 ### 🚀 Features
 
 - feat: add support for additional target architectures in CI configura… [@amitksingh1490](https://github.com/amitksingh1490) ([#333](https://github.com/antinomyhq/forge/pull/333))
 
----
 
-## v0.15.0
+---
+## v0.15.0 
 
 ### 🚀 Features
 
@@ -186,42 +199,42 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - fix: use bundled sqlite [@ssddOnTop](https://github.com/ssddOnTop) ([#336](https://github.com/antinomyhq/forge/pull/336))
 
----
 
-## v0.14.0
+---
+## v0.14.0 
 
 ### 🚀 Features
 
 - feat: add unrestricted shell mode and update environment handling in CLI [@tusharmath](https://github.com/tusharmath) ([#329](https://github.com/antinomyhq/forge/pull/329))
 
----
 
-## v0.13.3
+---
+## v0.13.3 
 
 ### 🐛 Bug Fixes
 
 - fix: optimize CI configuration and release profile settings [@amitksingh1490](https://github.com/amitksingh1490) ([#330](https://github.com/antinomyhq/forge/pull/330))
 
----
 
-## v0.13.2
+---
+## v0.13.2 
 
 ### 🐛 Bug Fixes
 
 - fix: update download URL in install script to remove file extension [@amitksingh1490](https://github.com/amitksingh1490) ([#328](https://github.com/antinomyhq/forge/pull/328))
-- fix: use APP_VERSION constant [@amitksingh1490](https://github.com/amitksingh1490) ([#327](https://github.com/antinomyhq/forge/pull/327))
+- fix: use APP\_VERSION constant [@amitksingh1490](https://github.com/amitksingh1490) ([#327](https://github.com/antinomyhq/forge/pull/327))
+
 
 ---
-
-## v0.13.1
+## v0.13.1 
 
 ### 🧰 Maintenance
 
 - chore: add Apache License 2.0 to the repository [@amitksingh1490](https://github.com/amitksingh1490) ([#326](https://github.com/antinomyhq/forge/pull/326))
 
----
 
-## v0.13.0
+---
+## v0.13.0 
 
 ### 🚀 Features
 
@@ -232,58 +245,58 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - doc: add installation script and README for Code-Forge [@tusharmath](https://github.com/tusharmath) ([#324](https://github.com/antinomyhq/forge/pull/324))
 
----
 
-## v0.12.0
+---
+## v0.12.0 
 
 ### 🚀 Features
 
 - feat: add support for Mistralai Codestral 2501 model [@amitksingh1490](https://github.com/amitksingh1490) ([#320](https://github.com/antinomyhq/forge/pull/320))
 
----
 
-## v0.11.1
+---
+## v0.11.1 
 
 ### 📝 Documentation
 
 - feat: add `-p` option to specify the prompt [@tusharmath](https://github.com/tusharmath) ([#321](https://github.com/antinomyhq/forge/pull/321))
 
----
 
-## v0.11.0
+---
+## v0.11.0 
 
 ### 🚀 Features
 
 - fix: add 'Required' option to ToolChoice and set parallel tool calls [@amitksingh1490](https://github.com/amitksingh1490) ([#318](https://github.com/antinomyhq/forge/pull/318))
 
----
 
-## v0.10.1
+---
+## v0.10.1 
 
 ### 📝 Documentation
 
 - fix: update system prompt to leverage shell commands more [@tusharmath](https://github.com/tusharmath) ([#319](https://github.com/antinomyhq/forge/pull/319))
 
----
 
-## v0.10.0
+---
+## v0.10.0 
 
 ### 🚀 Features
 
 - feat: add tool choice for Gemini model in OpenRouter request [@amitksingh1490](https://github.com/amitksingh1490) ([#317](https://github.com/antinomyhq/forge/pull/317))
 
----
 
-## v0.9.0
+---
+## v0.9.0 
 
 ### 🚀 Features
 
 - feat: add tool choice for Gemini model in OpenRouter request [@amitksingh1490](https://github.com/amitksingh1490) ([#317](https://github.com/antinomyhq/forge/pull/317))
 - feat: enhance output of search message [@tusharmath](https://github.com/tusharmath) ([#316](https://github.com/antinomyhq/forge/pull/316))
 
----
 
-## v0.8.0
+---
+## v0.8.0 
 
 ### 🚀 Features
 
@@ -293,19 +306,19 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 ### 🧰 Maintenance
 
 - fix: improve title formats [@tusharmath](https://github.com/tusharmath) ([#313](https://github.com/antinomyhq/forge/pull/313))
-- refactor: remove forge_pretty_diff crate and update dependencies [@tusharmath](https://github.com/tusharmath) ([#312](https://github.com/antinomyhq/forge/pull/312))
+- refactor: remove forge\_pretty\_diff crate and update dependencies [@tusharmath](https://github.com/tusharmath) ([#312](https://github.com/antinomyhq/forge/pull/312))
+
 
 ---
-
-## v0.7.0
+## v0.7.0 
 
 ### 🚀 Features
 
 - feat: add a tool for removing files [@tusharmath](https://github.com/tusharmath) ([#310](https://github.com/antinomyhq/forge/pull/310))
 
----
 
-## v0.6.0
+---
+## v0.6.0 
 
 - refactor: workflow iteration feb 6 [@tusharmath](https://github.com/tusharmath) ([#308](https://github.com/antinomyhq/forge/pull/308))
 - refactor: remove Errata [@tusharmath](https://github.com/tusharmath) ([#300](https://github.com/antinomyhq/forge/pull/300))
@@ -323,19 +336,19 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 ### 🧰 Maintenance
 
-- refactor: remove unused model tests from api_spec [@amitksingh1490](https://github.com/amitksingh1490) ([#305](https://github.com/antinomyhq/forge/pull/305))
+- refactor: remove unused model tests from api\_spec [@amitksingh1490](https://github.com/amitksingh1490) ([#305](https://github.com/antinomyhq/forge/pull/305))
+
 
 ---
-
-## v0.5.0
+## v0.5.0 
 
 ### 🚀 Features
 
 - feat: impl config commands [@laststylebender14](https://github.com/laststylebender14) ([#288](https://github.com/antinomyhq/forge/pull/288))
 
----
 
-## v0.4.0
+---
+## v0.4.0 
 
 - refactor: improve folder structure for workflows [@tusharmath](https://github.com/tusharmath) ([#292](https://github.com/antinomyhq/forge/pull/292))
 
@@ -343,9 +356,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - feat: show the models on `/models` command [@laststylebender14](https://github.com/laststylebender14) ([#289](https://github.com/antinomyhq/forge/pull/289))
 
----
 
-## v0.3.3
+---
+## v0.3.3 
 
 ### 🐛 Bug Fixes
 
@@ -356,9 +369,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - refactor: rename ToolCallService trait to ExecutableTool and update references [@tusharmath](https://github.com/tusharmath) ([#291](https://github.com/antinomyhq/forge/pull/291))
 
----
 
-## v0.3.2
+---
+## v0.3.2 
 
 ### 🐛 Bug Fixes
 
@@ -368,9 +381,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - refactor: agentic workflows [@tusharmath](https://github.com/tusharmath) ([#284](https://github.com/antinomyhq/forge/pull/284))
 
----
 
-## v0.3.1
+---
+## v0.3.1 
 
 - refactor: enhance chat response handling and XML tool call parsing [@tusharmath](https://github.com/tusharmath) ([#281](https://github.com/antinomyhq/forge/pull/281))
 
@@ -378,9 +391,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - fix: shell issues [@laststylebender14](https://github.com/laststylebender14) ([#283](https://github.com/antinomyhq/forge/pull/283))
 
----
 
-## v0.3.0
+---
+## v0.3.0 
 
 ### 🚀 Features
 
@@ -390,9 +403,9 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - fix: update environment variable and repository references in CI [@amitksingh1490](https://github.com/amitksingh1490) ([#280](https://github.com/antinomyhq/forge/pull/280))
 
----
 
-## v0.2.7
+---
+## v0.2.7 
 
 ### 🐛 Bug Fixes
 
@@ -403,56 +416,56 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 - refactor: move env constructors into domain [@tusharmath](https://github.com/tusharmath) ([#277](https://github.com/antinomyhq/forge/pull/277))
 
----
 
-## v0.2.6
+---
+## v0.2.6 
 
 ### 🐛 Bug Fixes
 
 - fix(deps): update rust crate tree-sitter to v0.25.1 @[renovate[bot]](https://github.com/apps/renovate) (#276)
 
----
-
-## v0.2.5
-
-- No changes
 
 ---
+## v0.2.5 
 
-## v0.2.4
+* No changes
+
+
+---
+## v0.2.4 
 
 ### 🐛 Bug Fixes
 
 - fix(deps): update rust crate syn to v2.0.98 @[renovate[bot]](https://github.com/apps/renovate) (#274)
 
----
 
-## v0.2.3
+---
+## v0.2.3 
 
 ### 🐛 Bug Fixes
 
 - fix(deps): update rust crate syn to v2.0.97 @[renovate[bot]](https://github.com/apps/renovate) (#273)
 - fix: crash with Open Router [@amitksingh1490](https://github.com/amitksingh1490) ([#272](https://github.com/antinomyhq/forge/pull/272))
 
----
-
-## v0.2.2
-
-- No changes
 
 ---
+## v0.2.2 
 
-## v0.2.1
+* No changes
 
-- No changes
 
 ---
+## v0.2.1 
 
-## v0.2.0
+* No changes
+
+
+---
+## v0.2.0 
 
 ### 🚀 Features
 
-- feat: update CI workflow and release drafter configuration [@amitksingh1490](https://github.com/amitksingh1490) ([#268](https://github.com/antinomyhq/forge/pull/268))
+- feat: update CI workflow and release drafter configuration  [@amitksingh1490](https://github.com/amitksingh1490) ([#268](https://github.com/antinomyhq/forge/pull/268))
 - feat: integrate reedline crate for cli prompting [@laststylebender14](https://github.com/laststylebender14) ([#263](https://github.com/antinomyhq/forge/pull/263))
 
 ### 🐛 Bug Fixes
@@ -460,10 +473,26 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - fix(deps): update rust crate tree-sitter to 0.25 @[renovate[bot]](https://github.com/apps/renovate) (#270)
 - fix(deps): update rust crate async-trait to v0.1.86 @[renovate[bot]](https://github.com/apps/renovate) (#269)
 
----
 
-## v0.1.3
+---
+## v0.1.3 
 
 ### 🐛 Bug Fixes
 
-- fix: update CI workflow to use GITHUB_TOKEN for script execution [@amitksingh1490](https://github.com/amitksingh1490) ([#267](https://github.com/antinomyhq/forge/pull/267))
+- fix: update CI workflow to use GITHUB\_TOKEN for script execution [@amitksingh1490](https://github.com/amitksingh1490) ([#267](https://github.com/antinomyhq/forge/pull/267))
+
+
+---
+## v0.1.2 
+
+- ci: update release drafter configuration for pull request\_target [@amitksingh1490](https://github.com/amitksingh1490) ([#261](https://github.com/antinomyhq/forge/pull/261))
+
+### 🚀 Features
+
+- feat: enhance CI workflow with draft release and versioning support [@amitksingh1490](https://github.com/amitksingh1490) ([#266](https://github.com/antinomyhq/forge/pull/266))
+- feat: drop support for file parsing in user prompt [@laststylebender14](https://github.com/laststylebender14) ([#262](https://github.com/antinomyhq/forge/pull/262))
+
+### 🐛 Bug Fixes
+
+- fix(deps): update rust crate diesel to v2.2.7 @[renovate[bot]](https://github.com/apps/renovate) (#264)
+- fix: drop the task in chat.rs as soon as base stream is dropped [@laststylebender14](https://github.com/laststylebender14) ([#259](https://github.com/antinomyhq/forge/pull/259))

--- a/releases/2025/January.mdx
+++ b/releases/2025/January.mdx
@@ -7,38 +7,19 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 
 <VersionUpdateCard />
 
-## v0.1.2
-
-- ci: update release drafter configuration for pull request_target [@amitksingh1490](https://github.com/amitksingh1490) ([#261](https://github.com/antinomyhq/forge/pull/261))
-
-### 🚀 Features
-
-- feat: enhance CI workflow with draft release and versioning support [@amitksingh1490](https://github.com/amitksingh1490) ([#266](https://github.com/antinomyhq/forge/pull/266))
-- feat: drop support for file parsing in user prompt [@laststylebender14](https://github.com/laststylebender14) ([#262](https://github.com/antinomyhq/forge/pull/262))
-
-### 🐛 Bug Fixes
-
-- fix(deps): update rust crate diesel to v2.2.7 @[renovate[bot]](https://github.com/apps/renovate) (#264)
-- fix: drop the task in chat.rs as soon as base stream is dropped [@laststylebender14](https://github.com/laststylebender14) ([#259](https://github.com/antinomyhq/forge/pull/259))
-
----
-
-## v0.1.1
+## v0.1.1 
 
 ### What's Changed
-
 - feat: pass on transformations for open router requests [@laststylebender14](https://github.com/laststylebender14) ([#260](https://github.com/antinomyhq/forge/pull/260))
 
 ### 👥 Contributors
-
 @amitksingh1490 and @laststylebender14
 
----
 
-## v0.1.0
+---
+## v0.1.0 
 
 ### What's Changed
-
 - feat: migrate release drafter workflow to root directory and update t… [@amitksingh1490](https://github.com/amitksingh1490) ([#257](https://github.com/antinomyhq/forge/pull/257))
 - chore(deps): update release-drafter/release-drafter action to v6 @[renovate[bot]](https://github.com/apps/renovate) (#254)
 - feat: add release drafter workflow for automated release updates [@amitksingh1490](https://github.com/amitksingh1490) ([#256](https://github.com/antinomyhq/forge/pull/256))
@@ -51,7 +32,7 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - fix(deps): update rust crate serde_json to v1.0.138 @[renovate[bot]](https://github.com/apps/renovate) (#244)
 - fix(deps): update rust crate tempfile to v3.16.0 @[renovate[bot]](https://github.com/apps/renovate) (#245)
 - fix: update Walker initialization to use `min` and `max` methods [@tusharmath](https://github.com/tusharmath) ([#241](https://github.com/antinomyhq/forge/pull/241))
-- fix: disable overwrite feature on fs_write. [@tusharmath](https://github.com/tusharmath) ([#240](https://github.com/antinomyhq/forge/pull/240))
+- fix: disable overwrite feature on fs_write.  [@tusharmath](https://github.com/tusharmath) ([#240](https://github.com/antinomyhq/forge/pull/240))
 - refactor: reorganize conversation history handling and improve structure [@tusharmath](https://github.com/tusharmath) ([#239](https://github.com/antinomyhq/forge/pull/239))
 - fix: walker settings for fs-find [@tusharmath](https://github.com/tusharmath) ([#236](https://github.com/antinomyhq/forge/pull/236))
 - feat: add new `forge_inte` crate [@tusharmath](https://github.com/tusharmath) ([#227](https://github.com/antinomyhq/forge/pull/227))
@@ -106,7 +87,7 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - fix: improve syntax validation error handling and messages [@tusharmath](https://github.com/tusharmath) ([#160](https://github.com/antinomyhq/forge/pull/160))
 - fix: remove timeout enforcement from shell command execution and related tests [@tusharmath](https://github.com/tusharmath) ([#158](https://github.com/antinomyhq/forge/pull/158))
 - fix: refactor ToolResult handling to use success and failure methods for better clarity [@tusharmath](https://github.com/tusharmath) ([#159](https://github.com/antinomyhq/forge/pull/159))
-- fix: implement display upstream error [@laststylebender14](https://github.com/laststylebender14) ([#132](https://github.com/antinomyhq/forge/pull/132))
+- fix: implement display upstream error  [@laststylebender14](https://github.com/laststylebender14) ([#132](https://github.com/antinomyhq/forge/pull/132))
 - refactor: drop model from context [@tusharmath](https://github.com/tusharmath) ([#151](https://github.com/antinomyhq/forge/pull/151))
 - refactor: env root api refac [@tusharmath](https://github.com/tusharmath) ([#156](https://github.com/antinomyhq/forge/pull/156))
 - fix: always display tool call results on error or in verbose mode [@tusharmath](https://github.com/tusharmath) ([#157](https://github.com/antinomyhq/forge/pull/157))
@@ -183,7 +164,7 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - fix(deps): update rust crate reqwest to v0.12.10 @[renovate[bot]](https://github.com/apps/renovate) (#46)
 - fix: match tool prompts and add concrete unit tests. [@laststylebender14](https://github.com/laststylebender14) ([#43](https://github.com/antinomyhq/forge/pull/43))
 - fix tests [@ssddOnTop](https://github.com/ssddOnTop) ([#47](https://github.com/antinomyhq/forge/pull/47))
-- feat: add more env variables [@laststylebender14](https://github.com/laststylebender14) ([#44](https://github.com/antinomyhq/forge/pull/44))
+- feat: add more env variables  [@laststylebender14](https://github.com/laststylebender14) ([#44](https://github.com/antinomyhq/forge/pull/44))
 - feat: render templates in sysprompt. [@laststylebender14](https://github.com/laststylebender14) ([#42](https://github.com/antinomyhq/forge/pull/42))
 - fix: use forge walker in fs_list [@laststylebender14](https://github.com/laststylebender14) ([#41](https://github.com/antinomyhq/forge/pull/41))
 - fix(deps): update rust crate quote to v1.0.38 @[renovate[bot]](https://github.com/apps/renovate) (#37)
@@ -208,5 +189,4 @@ import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
 - feat: add basic LLM capabilities [@tusharmath](https://github.com/tusharmath) ([#2](https://github.com/antinomyhq/forge/pull/2))
 
 ### 👥 Contributors
-
 @amitksingh1490, @autofix-ci[bot], @laststylebender14, @renovate[bot], @ssddOnTop, @tusharmath, AI Assistant and [renovate[bot]](https://github.com/apps/renovate)

--- a/releases/2025/March.mdx
+++ b/releases/2025/March.mdx
@@ -1,0 +1,232 @@
+---
+sidebar_position: 10
+toc_max_heading_level: 2
+slug: /
+---
+
+import VersionUpdateCard from "@site/src/components/shared/VersionUpdateCard"
+
+<VersionUpdateCard />
+
+## v0.36.2 
+
+### 🧰 Maintenance
+
+- feat(config): support workflow merge [@tusharmath](https://github.com/tusharmath) ([#478](https://github.com/antinomyhq/forge/pull/478))
+
+
+---
+## v0.36.1 
+
+### 🐛 Bug Fixes
+
+- fix(ui): integrate tracker dispatch for prompt events in user input handling [@amitksingh1490](https://github.com/amitksingh1490) ([#479](https://github.com/antinomyhq/forge/pull/479))
+
+
+---
+## v0.36.0 
+
+### 🚀 Features
+
+- feat: implement file snapshot system [@ssddOnTop](https://github.com/ssddOnTop) ([#457](https://github.com/antinomyhq/forge/pull/457))
+
+### 🐛 Bug Fixes
+
+- fix: set `forge_fs` and `forge_walker` to workspace [@ssddOnTop](https://github.com/ssddOnTop) ([#481](https://github.com/antinomyhq/forge/pull/481))
+
+### 🧰 Maintenance
+
+- chore: update Rust edition from 2024 to 2021 in Cargo.toml [@amitksingh1490](https://github.com/amitksingh1490) ([#480](https://github.com/antinomyhq/forge/pull/480))
+
+
+---
+## v0.35.0 
+
+### 🚀 Features
+
+- feat: add help command mode with dedicated help agent [@tusharmath](https://github.com/tusharmath) ([#475](https://github.com/antinomyhq/forge/pull/475))
+
+
+---
+## v0.34.0 
+
+### 🚀 Features
+
+- feat(tools): introduce agent-level tool support configuration [@tusharmath](https://github.com/tusharmath) ([#476](https://github.com/antinomyhq/forge/pull/476))
+
+
+---
+## v0.33.0 
+
+### 🚀 Features
+
+- feat(provider): add support for custom provider URLs [@tusharmath](https://github.com/tusharmath) ([#474](https://github.com/antinomyhq/forge/pull/474))
+
+### 📝 Documentation
+
+- doc: add application logs documentation to README [@tusharmath](https://github.com/tusharmath) ([#470](https://github.com/antinomyhq/forge/pull/470))
+
+### 🧰 Maintenance
+
+- chore: move dependencies to root `Cargo.toml` [@ssddOnTop](https://github.com/ssddOnTop) ([#471](https://github.com/antinomyhq/forge/pull/471))
+
+
+---
+## v0.32.1 
+
+### 🐛 Bug Fixes
+
+- fix: change logging format to `json` [@tusharmath](https://github.com/tusharmath) ([#469](https://github.com/antinomyhq/forge/pull/469))
+
+
+---
+## v0.32.0 
+
+- fix: separate default forge config from user config [@tusharmath](https://github.com/tusharmath) ([#466](https://github.com/antinomyhq/forge/pull/466))
+
+### 🚀 Features
+
+- fix(auth): simplify provider handling with URL-based configuration [@tusharmath](https://github.com/tusharmath) ([#465](https://github.com/antinomyhq/forge/pull/465))
+- Revert "feat(oauth): implement authentication flow with login and logout" [@tusharmath](https://github.com/tusharmath) ([#464](https://github.com/antinomyhq/forge/pull/464))
+
+### 🧰 Maintenance
+
+- fix(auth): simplify provider handling with URL-based configuration [@tusharmath](https://github.com/tusharmath) ([#465](https://github.com/antinomyhq/forge/pull/465))
+
+
+---
+## v0.31.0 
+
+### 🚀 Features
+
+- fix(auth): simplify provider handling with URL-based configuration [@tusharmath](https://github.com/tusharmath) ([#465](https://github.com/antinomyhq/forge/pull/465))
+- Revert "feat(oauth): implement authentication flow with login and logout" [@tusharmath](https://github.com/tusharmath) ([#464](https://github.com/antinomyhq/forge/pull/464))
+- feat(oauth): implement authentication flow with login and logout [@amitksingh1490](https://github.com/amitksingh1490) ([#442](https://github.com/antinomyhq/forge/pull/442))
+
+### 🧰 Maintenance
+
+- fix(auth): simplify provider handling with URL-based configuration [@tusharmath](https://github.com/tusharmath) ([#465](https://github.com/antinomyhq/forge/pull/465))
+
+
+---
+## v0.30.0 
+
+### 🚀 Features
+
+- feat: Add Act and Plan modes [@tusharmath](https://github.com/tusharmath) ([#460](https://github.com/antinomyhq/forge/pull/460))
+
+### 🧰 Maintenance
+
+- feat: Add Act and Plan modes [@tusharmath](https://github.com/tusharmath) ([#460](https://github.com/antinomyhq/forge/pull/460))
+
+
+---
+## v0.29.3 
+
+### 🐛 Bug Fixes
+
+- fix(prompt): enhance user collaboration and feedback workflow [@tusharmath](https://github.com/tusharmath) ([#458](https://github.com/antinomyhq/forge/pull/458))
+
+
+---
+## v0.29.2 
+
+### 🐛 Bug Fixes
+
+- fix: system prompt improvements and shell tool formatting [@tusharmath](https://github.com/tusharmath) ([#453](https://github.com/antinomyhq/forge/pull/453))
+
+
+---
+## v0.29.1 
+
+### 🐛 Bug Fixes
+
+- fix: improve error handling for tool call parsing [@tusharmath](https://github.com/tusharmath) ([#447](https://github.com/antinomyhq/forge/pull/447))
+
+### 🧰 Maintenance
+
+- refactor: migrate from content-based to event-based communication model [@tusharmath](https://github.com/tusharmath) ([#446](https://github.com/antinomyhq/forge/pull/446))
+
+
+---
+## v0.29.0 
+
+### 🚀 Features
+
+- feat(patch): support multiple-patch operations in a single call [@tusharmath](https://github.com/tusharmath) ([#445](https://github.com/antinomyhq/forge/pull/445))
+
+### 🐛 Bug Fixes
+
+- feat(patch): support multiple-patch operations in a single call [@tusharmath](https://github.com/tusharmath) ([#445](https://github.com/antinomyhq/forge/pull/445))
+
+
+---
+## v0.28.2 
+
+### 🐛 Bug Fixes
+
+- fix: version in `/info`  [@ssddOnTop](https://github.com/ssddOnTop) ([#444](https://github.com/antinomyhq/forge/pull/444))
+
+
+---
+## v0.28.1 
+
+### 🐛 Bug Fixes
+
+- fix: add diff output display to `apply_json.rs` [@tusharmath](https://github.com/tusharmath) ([#443](https://github.com/antinomyhq/forge/pull/443))
+
+
+---
+## v0.28.0 
+
+- chore: add nextest.toml configuration for test timeouts [@tusharmath](https://github.com/tusharmath) ([#438](https://github.com/antinomyhq/forge/pull/438))
+
+### 🚀 Features
+
+- feat: ability to attach images [@ssddOnTop](https://github.com/ssddOnTop) ([#378](https://github.com/antinomyhq/forge/pull/378))
+- feat: display Version in `/info` [@ssddOnTop](https://github.com/ssddOnTop) ([#434](https://github.com/antinomyhq/forge/pull/434))
+
+### 🐛 Bug Fixes
+
+- fix: Make walker depth optional and more flexible in template agent [@tusharmath](https://github.com/tusharmath) ([#431](https://github.com/antinomyhq/forge/pull/431))
+
+### 🧰 Maintenance
+
+- chore: ability to disable `test_find_cat_name` [@ssddOnTop](https://github.com/ssddOnTop) ([#441](https://github.com/antinomyhq/forge/pull/441))
+- fix: Make walker depth optional and more flexible in template agent [@tusharmath](https://github.com/tusharmath) ([#431](https://github.com/antinomyhq/forge/pull/431))
+
+
+---
+## v0.27.0 
+
+- refactor: Make system\_prompt and user\_prompt fields optional for agents [@tusharmath](https://github.com/tusharmath) ([#418](https://github.com/antinomyhq/forge/pull/418))
+
+### 🚀 Features
+
+- feat(fs-patch): replace fuzzy patching with operation-based exact patching [@tusharmath](https://github.com/tusharmath) ([#429](https://github.com/antinomyhq/forge/pull/429))
+- feat(template): add agent reference to template service [@tusharmath](https://github.com/tusharmath) ([#427](https://github.com/antinomyhq/forge/pull/427))
+
+### 🐛 Bug Fixes
+
+- fix: replace `OPEN_ROUTER_KEY` with `OPENROUTER_API_KEY` [@DrSensor](https://github.com/DrSensor) ([#425](https://github.com/antinomyhq/forge/pull/425))
+
+
+---
+## v0.26.0 
+
+### 🚀 Features
+
+- feat: add overwrite option to FSWriteInput for file writing behavior [@tusharmath](https://github.com/tusharmath) ([#417](https://github.com/antinomyhq/forge/pull/417))
+
+### 📝 Documentation
+
+- docs: add Discord community section to README with invitation and badge [@amitksingh1490](https://github.com/amitksingh1490) ([#412](https://github.com/antinomyhq/forge/pull/412))
+- docs: streamline README by removing outdated API key section and enhancing feature descriptions [@amitksingh1490](https://github.com/amitksingh1490) ([#396](https://github.com/antinomyhq/forge/pull/396))
+
+### 🐛 Bug Fixes
+
+- Rename DispatchEvent to Event [@tusharmath](https://github.com/tusharmath) ([#410](https://github.com/antinomyhq/forge/pull/410))
+
+### 🧰 Maintenance
+
+- refactor: Move Provider tests to forge\_infra with sequential execution [@tusharmath](https://github.com/tusharmath) ([#414](https://github.com/antinomyhq/forge/pull/414))


### PR DESCRIPTION
This is a manually created pull request that updates releases. It runs the release-notes-generator.js script to fetch the latest release information from the antinomyhq/forge repository.