### PR TITLE
Fix: Correct blog back button navigation

### DIFF
--- a/src/theme/BlogPostItem/Header/Back/index.tsx
+++ b/src/theme/BlogPostItem/Header/Back/index.tsx
@@ -4,7 +4,7 @@ import React from "react"
 
 export default function BlogBackButton(): JSX.Element {
   return (
-    <Link to="/" className="flex items-center gap-2 my-8 cursor-pointer !no-underline" onClick={() => {}}>
+    <Link to="/blog" className="flex items-center gap-2 my-8 cursor-pointer !no-underline" onClick={() => {}}>
       <ArrowLeft size={24} color="black" />
       <span className="text-content-small text-tailCall-light-600">Back to Blogs</span>
     </Link>


### PR DESCRIPTION
## Problem
The 'Back to Blogs' button on blog post pages was incorrectly navigating users to the home page (/) instead of the blog listing page (/blog).

## Solution
Updated the BlogBackButton component to use the correct route:
- Changed  to  in the Link component

## Changes
- Modified 
- Fixed navigation UX issue for better user experience

## Testing
- Verified the link now correctly points to 
- No breaking changes to existing functionality

This is a simple but important UX fix that ensures users can properly navigate back to the blog listing page.