### PR TITLE
fix: refactor home page: move GitHub stats from Banner to Stats section

### DIFF
--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -36,21 +36,6 @@ const Banner = (): JSX.Element => {
               onClick={() => analyticsHandler("Home Page", "Click", "Get Started")}
             />
           </div>
-          <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-8 pt-6 border-t border-gray-200">
-            <div className="flex justify-center">
-              <a
-                href="https://github.com/antinomyhq/forge"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-gray-100 rounded-full text-sm font-medium text-gray-700 transition-all duration-200 hover:no-underline shadow-lg"
-                onClick={() => analyticsHandler("Home Page", "Click", "GitHub Badge")}
-              >
-                <Github size={28} />
-                <Star size={28} className="text-yellow-500" />
-                <span className="font-medium text-base">3.8k on GitHub</span>
-              </a>
-            </div>
-          </div>
         </div>
       </Section>
     </main>

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Section from "../shared/Section"
 import AnimatedCounter from "../shared/AnimatedCounter"
-import {Info, Coins, Code} from "lucide-react"
+import {Info, Coins, Code, Github} from "lucide-react"
 import TrustedByMarquee from "./TrustedByMarquee"
 import {clientLogos} from "@site/src/constants"
 
@@ -23,7 +23,7 @@ const Stats = (): JSX.Element => {
     {
       value: 1790000000,
       suffix: "+",
-      label: "Tokens Consumed",
+      label: "Tokens",
       description: "/ day",
       infoLink: "https://openrouter.ai/apps?url=https%3A%2F%2Fforgecode.dev%2F",
       icon: Coins,
@@ -31,38 +31,48 @@ const Stats = (): JSX.Element => {
     {
       value: 1400000,
       suffix: "+",
-      label: "Lines of Code Generated",
+      label: "Lines of Code",
       description: "/ day",
       icon: Code,
+    },
+    {
+      value: 3800,
+      suffix: "+",
+      label: "GitHub Stars",
+      description: "",
+      infoLink: "https://github.com/antinomyhq/forge",
+      icon: Github,
     },
   ]
 
   return (
     <Section>
-      <div className="flex flex-wrap justify-center items-start gap-4 w-full max-w-4xl mx-auto">
+      <div className="flex flex-col sm:flex-row flex-wrap justify-center items-center gap-8 w-full max-w-5xl mx-auto">
         {stats.map((stat, index) => (
           <div
             key={index}
-            className="group p-2 flex flex-col items-center cursor-pointer text-center min-w-0 flex-1 max-w-sm"
+            className="group p-2 flex flex-col items-center text-center w-full sm:w-auto"
+            style={{minWidth: "180px"}}
           >
-            <div className="flex items-baseline">
+            {stat.infoLink ? (
+              <a href={stat.infoLink} target="_blank" rel="noopener noreferrer" className="cursor-pointer">
+                <stat.icon className="w-10 h-10 text-slate-500" />
+              </a>
+            ) : (
               <stat.icon className="w-10 h-10 text-slate-500" />
+            )}
+            <div className="mt-2 text-3xl font-bold">
+              <AnimatedCounter
+                end={stat.value}
+                suffix={stat.suffix}
+                formatter={formatNumber}
+                aria-label={stat.value.toLocaleString()}
+              />
+            </div>
+            <div className="text-content-tiny sm:text-content-small text-slate-600 mt-1 h-8 flex flex-col justify-center">
               <div>
-                <AnimatedCounter
-                  end={stat.value}
-                  suffix={stat.suffix}
-                  formatter={formatNumber}
-                  aria-label={stat.value.toLocaleString()}
-                />
-                <span className="text-content-tiny sm:text-content-small text-slate-600 ml-2">
-                  {stat.label} {stat.description}
-                  {stat.infoLink && (
-                    <Info
-                      className="inline-block w-3 h-3 ml-1 cursor-pointer text-slate-500 hover:text-slate-700 transition-colors"
-                      onClick={() => window.open(stat.infoLink, "_blank")}
-                    />
-                  )}
-                </span>
+                {stat.label} {stat.description}
+                {stat.infoLink && <Info className="inline-block w-3 h-3 ml-1 text-slate-500" />}
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Remove GitHub star badge from Banner component
- Add GitHub stars as new stat item in Stats component
- Improve Stats layout with better spacing and responsive design
- Simplify stat labels and add clickable GitHub link