### PR TITLE
fix: prevent Algolia search from hijacking Cmd+F browser find

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-fast-marquee": "^1.6.4",
         "react-ga4": "^2.1.0",
         "react-hot-toast": "^2.4.1",
+        "react-hotkeys-hook": "^5.1.0",
         "react-on-screen": "^2.1.1",
         "react-platform-js": "^0.0.1",
         "react-tweet": "^3.2.2",
@@ -20947,6 +20948,19 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.1.0.tgz",
+      "integrity": "sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-fast-marquee": "^1.6.4",
     "react-ga4": "^2.1.0",
     "react-hot-toast": "^2.4.1",
+    "react-hotkeys-hook": "^5.1.0",
     "react-on-screen": "^2.1.1",
     "react-platform-js": "^0.0.1",
     "react-tweet": "^3.2.2",


### PR DESCRIPTION
- Replace useDocSearchKeyboardEvents with react-hotkeys-hook for better cross-platform support
- Use 'mod+k' shortcut that automatically handles Cmd+K (Mac) and Ctrl+K (Windows/Linux)
- Explicitly exclude Cmd+F/Ctrl+F to allow native browser find functionality
- Add proper form input detection to prevent shortcuts when typing
- Maintain all existing search functionality (Escape to close, character input to search)

Fixes issue where pressing Cmd+F after using Cmd+K would open Algolia search instead of browser's native find dialog.